### PR TITLE
Remove outdated xenon.yml example file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 *.iml
 /.idea
-xenon.yml

--- a/xenon.yml.example
+++ b/xenon.yml.example
@@ -1,7 +1,0 @@
-browsers:
-  - name: chrome
-    driver_path: /usr/local/bin/chromedriver
-    max_sessions: 10
-  - name: firefox
-    driver_path: /usr/local/bin/geckodriver
-    max_sessions: 10


### PR DESCRIPTION
Looking at `.gitignore` I guess that the file was commited by mistake?

Or might not so it would be better to restore `.gitignore`

https://github.com/stevepryde/xenon/blob/03018ee065cb5403c05fcb31a0c3992e4aad920d/src/server.rs#L44