### PR TITLE
session/create: Add content-type parameter to the responce

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -155,6 +155,7 @@ impl Session {
 
         let resp_out = Response::builder()
             .status(response.status())
+            .header("Content-Type", "application/json")
             .body(Body::from(bytes_out))
             .map_err(|e| {
                 XenonError::RespondWith(XenonResponse::ErrorCreatingSession(e.to_string()))


### PR DESCRIPTION
Some tools/clients require to have a correct response type.
In other way they will consider the protocol no compatible with W3C.

I hope there are no more places where it's better to add such a header. 