### PR TITLE
Make driver_path optional, instead use default name of drivers

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -14,7 +14,7 @@ pub struct BrowserConfig {
     name: String,
     version: Option<String>,
     os: Option<String>,
-    driver_path: PathBuf,
+    driver_path: Option<PathBuf>,
     args: Option<Vec<String>>,
     #[serde(default = "default_sessions_per_driver")]
     sessions_per_driver: u32,
@@ -28,7 +28,17 @@ impl BrowserConfig {
     }
 
     pub fn driver_path(&self) -> &Path {
-        &self.driver_path.as_path()
+        match &self.driver_path {
+            Some(path) => path.as_path(),
+            _ => {
+                // it's better to move it to a serialization implemenation
+                match self.name.as_str() {
+                    "firefox" => "geckodriver".as_ref(),
+                    "chrome" => "chromedriver".as_ref(),
+                    _ => unimplemented!("There's no default webdriver name for {} browser", self.name),
+                }
+            }
+        }
     }
 
     pub fn args(&self) -> &Option<Vec<String>> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,8 +47,13 @@ pub fn load_config(config_path: &Path) -> Result<XenonConfig, XenonError> {
 
     let config_str = std::fs::read_to_string(config_path)
         .map_err(|e| XenonError::ConfigLoadError(config_path.to_path_buf(), e.to_string()))?;
-    let config = serde_yaml::from_str(&config_str)
+    let mut config: XenonConfig = serde_yaml::from_str(&config_str)
         .map_err(|e| XenonError::ConfigLoadError(config_path.to_path_buf(), e.to_string()))?;
+
+    for browser_cfg in &mut config.browsers {
+        browser_cfg.sanitize()?;
+    }
+
     Ok(config)
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ pub enum XenonError {
     ConfigNotFound(PathBuf),
     #[error("Error loading config from file '{0}': {1}")]
     ConfigLoadError(PathBuf, String),
+    #[error("Encountered an unexpected browser in config '{0}': {1}")]
+    ConfigUnexpectedBrowser(String, String),
     #[error("Error response returned to client")]
     RespondWith(XenonResponse),
     #[error("WebDriver response passed through to client")]


### PR DESCRIPTION
I am not sure though the match case like that worth it.

It would be better to add this transformation to a parse stage. But it's require a custom implementation of `Deserializer` or having a some a kind of `new` function.
But it would provide a performance win as well as a error detection from the outset.

So I have a mixed fillings about this PR.

I provide the PR in such state to show you that we need to match browser to its webdriver in any way. 

What do you think @stevepryde ?

ref #9 